### PR TITLE
[RST-6280] Support for YAML 6.0+

### DIFF
--- a/copyrightify/copyrightify.py
+++ b/copyrightify/copyrightify.py
@@ -168,7 +168,7 @@ def process_paths(paths, recursive, config, context):
 
 def main():
     try:
-        config = yaml.load(resource_string(__name__, 'config.yaml'), Loader=yaml.FullLoader)
+        config = yaml.load(resource_string(__name__, 'config.yaml'), Loader=yaml.SafeLoader)
 
         parser = argparse.ArgumentParser()
         parser.add_argument('paths', type=str, nargs='+', help='Path to process')

--- a/copyrightify/copyrightify.py
+++ b/copyrightify/copyrightify.py
@@ -168,7 +168,7 @@ def process_paths(paths, recursive, config, context):
 
 def main():
     try:
-        config = yaml.load(resource_string(__name__, 'config.yaml'))
+        config = yaml.load(resource_string(__name__, 'config.yaml'), Loader=yaml.FullLoader)
 
         parser = argparse.ArgumentParser()
         parser.add_argument('paths', type=str, nargs='+', help='Path to process')


### PR DESCRIPTION
Added a line which will remove the error `Error: load() missing 1 required positional argument: 'Loader'`.
Related PR: https://github.com/yaml/pyyaml/pull/561
The branch protection rules were not set for the `master`. I have added them as well. Please have a look at them too. 
Tested versions:
- `python: 3.8`
- `yaml: 6.0`